### PR TITLE
Resolved buffer not defined bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ coverage/
 docs/
 node_modules/
 src/
-types/
 .eslintignore
 .eslintrc.yml
 jest.config.cjs

--- a/dist/bytereader.d.ts
+++ b/dist/bytereader.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+import { Buffer } from 'buffer';
 /**
  * ByteReader is a class for reading bytes from a buffer.
  * This class provides an efficient way to read byte-by-byte from a buffer.

--- a/dist/loadreader.d.ts
+++ b/dist/loadreader.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+import { Buffer } from 'buffer';
 import { ReadBuffer } from './readbuffer';
 import { WireType } from './wiretype';
 /**

--- a/dist/readbuffer.d.ts
+++ b/dist/readbuffer.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="node" />
+import { Buffer } from 'buffer';
 import LoadReader from './loadreader';
 import { WireType } from './wiretype';
 import { Raw } from './raw';

--- a/dist/readbuffer.js
+++ b/dist/readbuffer.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ReadBuffer = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const buffer_1 = require("buffer");
 const bytereader_1 = __importDefault(require("./bytereader"));
 const varint_1 = __importDefault(require("./varint"));
 const loadreader_1 = __importDefault(require("./loadreader"));
@@ -25,14 +26,14 @@ class ReadBuffer {
     constructor(data, wiretype) {
         if (wiretype) {
             this.wire = wiretype;
-            this.data = Buffer.from(data);
+            this.data = buffer_1.Buffer.from(data);
         }
         else {
-            const byteReader = new bytereader_1.default(Buffer.from(data));
+            const byteReader = new bytereader_1.default(buffer_1.Buffer.from(data));
             // Attempt to consume a varint from the buffer
             const [tag, consumed] = varint_1.default.consume(byteReader);
             this.wire = tag & 15;
-            this.data = Buffer.from(data).subarray(consumed);
+            this.data = buffer_1.Buffer.from(data).subarray(consumed);
         }
     }
     /**
@@ -72,9 +73,9 @@ class ReadBuffer {
     read(br, n) {
         // If n == 0, return an empty buffer
         if (n == 0) {
-            return Buffer.alloc(0);
+            return buffer_1.Buffer.alloc(0);
         }
-        const buffer = Buffer.alloc(n);
+        const buffer = buffer_1.Buffer.alloc(n);
         const rn = br.read(buffer);
         if (rn != n) {
             throw new Error('insufficient data in reader');

--- a/dist/writebuffer.js
+++ b/dist/writebuffer.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.WriteBuffer = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const buffer_1 = require("buffer");
 const varint_1 = __importDefault(require("./varint"));
 const wiretype_1 = require("./wiretype");
 const datarange_1 = require("./datarange");
@@ -182,13 +183,13 @@ class WriteBuffer {
                 break;
             case 1:
                 wiretype = wiretype_1.WireType.WIRE_POSINT;
-                buffer = Buffer.from(new bn_js_1.default(value).toArray('be', 8));
-                buffer = Buffer.from(buffer.subarray((8 - this.intSize(value))));
+                buffer = buffer_1.Buffer.from(new bn_js_1.default(value).toArray('be', 8));
+                buffer = buffer_1.Buffer.from(buffer.subarray((8 - this.intSize(value))));
                 break;
             default:
                 wiretype = wiretype_1.WireType.WIRE_NEGINT;
-                buffer = Buffer.from(new bn_js_1.default(-value).toArray('be', 8));
-                buffer = Buffer.from(buffer.subarray((8 - this.intSize(-value))));
+                buffer = buffer_1.Buffer.from(new bn_js_1.default(-value).toArray('be', 8));
+                buffer = buffer_1.Buffer.from(buffer.subarray((8 - this.intSize(-value))));
                 break;
         }
         this.write(wiretype, buffer);
@@ -201,7 +202,7 @@ class WriteBuffer {
      */
     writeFloat(value) {
         if (this.isFloat(value)) {
-            const buffer = Buffer.alloc(8);
+            const buffer = buffer_1.Buffer.alloc(8);
             buffer.writeDoubleBE(value, 0);
             this.write(wiretype_1.WireType.WIRE_FLOAT, buffer);
             return;
@@ -216,7 +217,7 @@ class WriteBuffer {
      * to the buffer.
      */
     writeString(value) {
-        this.write(wiretype_1.WireType.WIRE_WORD, Buffer.from(value, 'utf8'));
+        this.write(wiretype_1.WireType.WIRE_WORD, buffer_1.Buffer.from(value, 'utf8'));
     }
     /**
      * Writes the bytes from the given value to the write buffer with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-polo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "js-polo is the JS/TS implementation of the POLO Serialization Format.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,6 +28,7 @@
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
     "bn.js": "^5.2.1",
+    "buffer": "^6.0.3",
     "typescript": "^4.9.3"
   },
   "devDependencies": {

--- a/src/bytereader.ts
+++ b/src/bytereader.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 /**
  * ByteReader is a class for reading bytes from a buffer.
  * This class provides an efficient way to read byte-by-byte from a buffer.

--- a/src/loadreader.ts
+++ b/src/loadreader.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 import ByteReader from './bytereader';
 import { ReadBuffer } from './readbuffer';
 import Varint from './varint';

--- a/src/readbuffer.ts
+++ b/src/readbuffer.ts
@@ -1,4 +1,5 @@
 import BN from 'bn.js';
+import { Buffer } from 'buffer';
 import ByteReader from './bytereader';
 import Varint from './varint';
 import LoadReader from './loadreader';

--- a/src/writebuffer.ts
+++ b/src/writebuffer.ts
@@ -1,4 +1,5 @@
 import BN from 'bn.js';
+import { Buffer } from 'buffer';
 import Varint from './varint';
 import { WireType } from './wiretype';
 import { DataRange } from './datarange';


### PR DESCRIPTION
### Description
This pull request addresses the "buffer not defined" bug that occurred in the browser environment. The bug was caused by the usage of the "buffer" data type, which is not available in the browser's runtime.

- Resolves #13 

**Changes Made**
1. Resolved the issue by incorporating the "buffer" package, which provides a compatible solution for working with buffers in the browser environment.