### PR TITLE
Resolved Integer Size Bug

### DIFF
--- a/__tests__/utils/fuzzer.ts
+++ b/__tests__/utils/fuzzer.ts
@@ -3,8 +3,8 @@ import Crypto from 'crypto';
 import { Schema } from '../../types/schema';
 
 
-const MIN_INT32 = -2147483648;
-const MAX_INT32 = 2147483647;
+const MIN_INT53 = -Number.MAX_SAFE_INTEGER;
+const MAX_INT53 = Number.MAX_SAFE_INTEGER;
 const MIN_BIGINT = -9223372036854775808n;
 const MAX_BIGINT = 9223372036854775807n;
 
@@ -16,7 +16,7 @@ export class Fuzzer {
 	}
 
 	private randInt(): number {
-		return Math.floor(Math.random() * (MAX_INT32 - MIN_INT32)) + MIN_INT32;
+		return Math.floor(Math.random() * (MAX_INT53 - MIN_INT53)) + MIN_INT53;
 	}
 
 	private randUInt64(): number {

--- a/dist/writebuffer.js
+++ b/dist/writebuffer.js
@@ -61,8 +61,7 @@ class WriteBuffer {
     intSize(value) {
         // check if the input value is a number
         if (this.isInt(value)) {
-            // if the input value is smaller than 2 return 1, 
-            // otherwise calculate and return the size
+            // calculate and return the size
             return Math.ceil(Math.log2(value + 1) / 8);
         }
         // if the input value is not a number, return 8 bytes

--- a/dist/writebuffer.js
+++ b/dist/writebuffer.js
@@ -63,7 +63,7 @@ class WriteBuffer {
         if (this.isInt(value)) {
             // if the input value is smaller than 2 return 1, 
             // otherwise calculate and return the size
-            return (value < 2) ? 1 : Math.ceil(Math.log2(value) / 8);
+            return Math.ceil(Math.log2(value + 1) / 8);
         }
         // if the input value is not a number, return 8 bytes
         return 8;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-polo",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "js-polo is the JS/TS implementation of the POLO Serialization Format.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,8 +28,7 @@
   "license": "Apache-2.0 OR MIT",
   "dependencies": {
     "bn.js": "^5.2.1",
-    "buffer": "^6.0.3",
-    "typescript": "^4.9.3"
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@types/jest": "^28.1.3",
@@ -40,6 +39,7 @@
     "eslint": "^8.30.0",
     "jest": "^28.1.3",
     "ts-jest": "^28.0.3",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.3"
   }
 }

--- a/src/writebuffer.ts
+++ b/src/writebuffer.ts
@@ -61,8 +61,7 @@ export class WriteBuffer {
 	private intSize(value: number | BN): number {
 		// check if the input value is a number
 		if(this.isInt(value)) {
-			// if the input value is smaller than 2 return 1, 
-			// otherwise calculate and return the size
+			// calculate and return the size
 			return Math.ceil(Math.log2(value + 1) / 8);
 		}
 

--- a/src/writebuffer.ts
+++ b/src/writebuffer.ts
@@ -63,7 +63,7 @@ export class WriteBuffer {
 		if(this.isInt(value)) {
 			// if the input value is smaller than 2 return 1, 
 			// otherwise calculate and return the size
-			return (value < 2) ? 1 : Math.ceil(Math.log2(value) / 8);
+			return Math.ceil(Math.log2(value + 1) / 8);
 		}
 
 		// if the input value is not a number, return 8 bytes


### PR DESCRIPTION
### Description
This pull request addresses a bug in the intSize() method that caused incorrect byte size calculation for certain integer inputs, especially when the input value was equal to 256.

- Resolves #15 

**Changes Made**
1. Adjusted the calculation in the intSize() method to handle the edge case properly, ensuring that the correct byte size is returned for all integer inputs, including 256.

