### PR TITLE
fix: resolved the boolean array depolorization bug

### DIFF
--- a/src/depolorizer.ts
+++ b/src/depolorizer.ts
@@ -243,10 +243,7 @@ export class Depolorizer {
 				while(!pack.isDone()) {
 					// Depolorize the element into the element type
 					const element = pack.depolorize(schema.fields.values);
-					if(element) {
-						// const ele = pack.unpack(schema.fields.values, element);
-						arr.push(element);
-					}
+					arr.push(element);
 				}
 
 				return arr;


### PR DESCRIPTION
### Description
This pull request resolves the issue of producing invalid output when depolarizing polo bytes to a boolean array. The fix involves removing the redundant condition that checks for the presence of depolarized elements in the `depolarizeArray` method. With this adjustment, the output now correctly represents the original boolean values.

- Closes #20 